### PR TITLE
Added explicit version number

### DIFF
--- a/Formula/tztail.rb
+++ b/Formula/tztail.rb
@@ -3,6 +3,8 @@ class Tztail < Formula
     homepage "https://github.com/thecasualcoder/tztail"
     url "https://github.com/thecasualcoder/tztail/releases/download/1.1.0/tztail_1.1.0_darwin_amd64.tar.gz"
     sha256 "42df063dd5072aa4ea753e533554c8cff4845c6a2523c46b127e15022752c1cf"
+    version "1.1.0"
+    version_scheme 1
     def install
       bin.install "tztail"
     end


### PR DESCRIPTION
The default version number is interpreted as `64` from the url. 
- Added explicit version number
- Add version scheme to allow upgrade to new version (`1.1.0`) which is lesser than default version `64`