### PR TITLE
remove bottle field cause it has been deprecated

### DIFF
--- a/Formula/stevedore.rb
+++ b/Formula/stevedore.rb
@@ -6,8 +6,6 @@ class Stevedore < Formula
   version "3.1.1"
   sha256 "ceb6a86560937ba1592e2b199e037acfdd07cf39ced34ad66e9a9b773b18e7a8"
 
-  bottle :unneeded
-
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
Hi, the Homebrew has deprecated the `bottle :unneeded` (https://github.com/Homebrew/homebrew-core/issues/75943). It will be failed when tap this repo. So just need to remove this line.

```
~ ❯ brew tap thecasualcoder/stable                                                                                                                        16s
==> Tapping thecasualcoder/stable
Cloning into '/usr/local/Homebrew/Library/Taps/thecasualcoder/homebrew-stable'...
remote: Enumerating objects: 200, done.
remote: Counting objects: 100% (49/49), done.
remote: Compressing objects: 100% (37/37), done.
remote: Total 200 (delta 22), reused 28 (delta 12), pack-reused 151
Receiving objects: 100% (200/200), 40.14 KiB | 224.00 KiB/s, done.
Resolving deltas: 100% (72/72), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/thecasualcoder/homebrew-stable/Formula/stevedore.rb
stevedore: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the thecasualcoder/stable tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/thecasualcoder/homebrew-stable/Formula/stevedore.rb:9

Error: Cannot tap thecasualcoder/stable: invalid syntax in tap!
```